### PR TITLE
fix: stabilize visual builder drag preview

### DIFF
--- a/frontend/src/app/features/decks/deck-profile.component.ts
+++ b/frontend/src/app/features/decks/deck-profile.component.ts
@@ -65,56 +65,69 @@ import { ToastService } from '../../core/services/toast.service';
       </header>
 
       <div class="deck-meta">
-        <div class="meta-item">
-          <span class="meta-label">{{ 'deckProfile.algorithm' | translate }}:</span>
+        <div class="meta-item meta-item-primary">
+          <span class="meta-icon" aria-hidden="true">⚙️</span>
+          <span class="meta-label">{{ 'deckProfile.algorithm' | translate }}</span>
           <span class="meta-value">{{ formatAlgorithmId(deck.algorithmId) }}</span>
         </div>
-        <div class="meta-item">
-          <span class="meta-label">{{ 'deckProfile.autoUpdate' | translate }}:</span>
+        <div class="meta-item" [class.meta-item-on]="deck.autoUpdate">
+          <span class="meta-icon" aria-hidden="true">↻</span>
+          <span class="meta-label">{{ 'deckProfile.autoUpdate' | translate }}</span>
           <span class="meta-value">{{ deck.autoUpdate ? ('deckProfile.yes' | translate) : ('deckProfile.no' | translate) }}</span>
         </div>
         <div class="meta-item" *ngIf="deck.publicDeckId">
-          <span class="meta-label">{{ 'deckProfile.version' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">#</span>
+          <span class="meta-label">{{ 'deckProfile.version' | translate }}</span>
           <span class="meta-value">{{ deck.currentVersion }}<span *ngIf="latestPublicVersion !== null"> / {{ latestPublicVersion }}</span></span>
         </div>
         <div class="meta-item" *ngIf="deck.templateVersion !== null && deck.templateVersion !== undefined">
-          <span class="meta-label">{{ 'deckProfile.templateVersion' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">▣</span>
+          <span class="meta-label">{{ 'deckProfile.templateVersion' | translate }}</span>
           <span class="meta-value">{{ deck.templateVersion }}<span *ngIf="latestTemplateVersion !== null"> / {{ latestTemplateVersion }}</span></span>
         </div>
         <div class="meta-item" *ngIf="!deck.publicDeckId">
-          <span class="meta-label">{{ 'deckProfile.version' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">#</span>
+          <span class="meta-label">{{ 'deckProfile.version' | translate }}</span>
           <span class="meta-value">{{ deck.currentVersion }}</span>
         </div>
         <div class="meta-item">
-          <span class="meta-label">{{ 'deckProfile.createdAt' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">＋</span>
+          <span class="meta-label">{{ 'deckProfile.createdAt' | translate }}</span>
           <span class="meta-value">{{ formatMetaDate(deck.createdAt) }}</span>
         </div>
         <div class="meta-item" *ngIf="deck.lastSyncedAt">
-          <span class="meta-label">{{ 'deckProfile.lastSyncedAt' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">✓</span>
+          <span class="meta-label">{{ 'deckProfile.lastSyncedAt' | translate }}</span>
           <span class="meta-value">{{ formatMetaDate(deck.lastSyncedAt) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck?.language">
-          <span class="meta-label">{{ 'deckProfile.language' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">A</span>
+          <span class="meta-label">{{ 'deckProfile.language' | translate }}</span>
           <span class="meta-value">{{ formatLanguageCode(publicDeck?.language) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck">
-          <span class="meta-label">{{ 'deckProfile.isPublic' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">◉</span>
+          <span class="meta-label">{{ 'deckProfile.isPublic' | translate }}</span>
           <span class="meta-value">{{ publicDeck.isPublic ? ('deckProfile.yes' | translate) : ('deckProfile.no' | translate) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck">
-          <span class="meta-label">{{ 'deckProfile.isListed' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">☰</span>
+          <span class="meta-label">{{ 'deckProfile.isListed' | translate }}</span>
           <span class="meta-value">{{ publicDeck.isListed ? ('deckProfile.yes' | translate) : ('deckProfile.no' | translate) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck?.publishedAt">
-          <span class="meta-label">{{ 'deckProfile.publishedAt' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">↑</span>
+          <span class="meta-label">{{ 'deckProfile.publishedAt' | translate }}</span>
           <span class="meta-value">{{ formatMetaDate(publicDeck?.publishedAt) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck?.updatedAt">
-          <span class="meta-label">{{ 'deckProfile.updatedAt' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">✎</span>
+          <span class="meta-label">{{ 'deckProfile.updatedAt' | translate }}</span>
           <span class="meta-value">{{ formatMetaDate(publicDeck?.updatedAt) }}</span>
         </div>
         <div class="meta-item" *ngIf="publicDeck?.forkedFromDeck">
-          <span class="meta-label">{{ 'deckProfile.forkedFrom' | translate }}:</span>
+          <span class="meta-icon" aria-hidden="true">⎇</span>
+          <span class="meta-label">{{ 'deckProfile.forkedFrom' | translate }}</span>
           <span class="meta-value">{{ publicDeck?.forkedFromDeck }}</span>
         </div>
       </div>
@@ -845,14 +858,16 @@ import { ToastService } from '../../core/services/toast.service';
       }
 
       .deck-meta {
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
         gap: var(--spacing-sm);
         padding: var(--spacing-lg);
-        background: var(--color-card-background);
-        border: 1px solid var(--border-color);
+        background: linear-gradient(135deg, var(--glass-surface-strong), var(--glass-surface));
+        border: 1px solid var(--glass-border);
         border-radius: var(--border-radius-lg);
         margin-bottom: var(--spacing-xl);
+        box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255, 255, 255, 0.45);
+        backdrop-filter: blur(var(--glass-blur));
       }
 
       .deck-stats-block {
@@ -862,12 +877,55 @@ import { ToastService } from '../../core/services/toast.service';
 
       .meta-item {
         display: flex;
-        gap: var(--spacing-md);
+        align-items: center;
+        gap: var(--spacing-sm);
+        min-width: 0;
+        padding: 0.8rem 0.9rem;
+        border: 1px solid var(--glass-border);
+        border-radius: var(--border-radius-md);
+        background: color-mix(in srgb, var(--color-surface-solid) 72%, transparent);
+      }
+
+      .meta-item-primary {
+        border-color: color-mix(in srgb, var(--color-primary-accent) 42%, var(--glass-border));
+        background: color-mix(in srgb, var(--color-primary-accent) 12%, var(--color-surface-solid));
+      }
+
+      .meta-item-on {
+        border-color: color-mix(in srgb, #16a34a 38%, var(--glass-border));
+      }
+
+      .meta-icon {
+        flex: 0 0 2rem;
+        width: 2rem;
+        height: 2rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--border-radius-sm);
+        color: var(--color-primary-accent);
+        background: var(--glass-surface-strong);
+        border: 1px solid var(--glass-border);
+        font-size: 0.9rem;
       }
 
       .meta-label {
+        flex: 1 1 auto;
+        min-width: 0;
         font-weight: 600;
-        min-width: 8rem;
+        font-size: 0.78rem;
+        line-height: 1.2;
+        color: var(--color-text-muted);
+        text-transform: uppercase;
+      }
+
+      .meta-value {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--color-text-primary);
+        font-weight: 600;
+        text-align: right;
       }
 
       .deck-actions {

--- a/frontend/src/app/features/public-decks/public-card-browser.component.ts
+++ b/frontend/src/app/features/public-decks/public-card-browser.component.ts
@@ -739,10 +739,11 @@ import { ToastService } from '../../core/services/toast.service';
       .modal-overlay {
         position: fixed;
         inset: 0;
-        background: rgba(15, 23, 42, 0.45);
-        backdrop-filter: blur(10px);
-        display: grid;
-        place-items: center;
+        background: rgba(8, 12, 22, 0.55);
+        backdrop-filter: blur(12px) saturate(140%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
         padding: var(--spacing-md);
         z-index: 1000;
       }
@@ -750,10 +751,12 @@ import { ToastService } from '../../core/services/toast.service';
       .modal-content {
         width: min(720px, 100%);
         max-height: 90vh;
-        overflow: auto;
-        border-radius: var(--border-radius-xl);
-        background: var(--color-card-background);
-        border: 1px solid var(--border-color);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        border-radius: var(--border-radius-lg);
+        background: var(--color-surface-solid);
+        border: 1px solid var(--glass-border);
         box-shadow: var(--shadow-lg);
       }
 
@@ -766,7 +769,8 @@ import { ToastService } from '../../core/services/toast.service';
       }
 
       .modal-header {
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--glass-border);
+        flex-shrink: 0;
       }
 
       .modal-header h2 {
@@ -778,6 +782,7 @@ import { ToastService } from '../../core/services/toast.service';
         display: flex;
         flex-direction: column;
         gap: var(--spacing-md);
+        overflow-y: auto;
       }
 
       .modal-body label {
@@ -802,7 +807,8 @@ import { ToastService } from '../../core/services/toast.service';
 
       .modal-actions {
         justify-content: flex-end;
-        border-top: 1px solid var(--border-color);
+        border-top: 1px solid var(--glass-border);
+        flex-shrink: 0;
       }
 
       .modal-error {

--- a/frontend/src/app/features/wizard/visual-template-builder.component.spec.ts
+++ b/frontend/src/app/features/wizard/visual-template-builder.component.spec.ts
@@ -1,0 +1,105 @@
+import { of } from 'rxjs';
+
+import { I18nService } from '../../core/services/i18n.service';
+import { VisualTemplateBuilderComponent } from './visual-template-builder.component';
+
+describe('VisualTemplateBuilderComponent', () => {
+    let component: VisualTemplateBuilderComponent;
+    let templateApi: jasmine.SpyObj<any>;
+    let router: jasmine.SpyObj<any>;
+    let wizardState: jasmine.SpyObj<any>;
+
+    beforeEach(() => {
+        localStorage.removeItem('mnema_visual_builder_draft');
+        localStorage.removeItem('mnema_language');
+
+        templateApi = jasmine.createSpyObj('TemplateApiService', ['createTemplate']);
+        router = jasmine.createSpyObj('Router', ['navigate']);
+        wizardState = jasmine.createSpyObj('DeckWizardStateService', ['setTemplateId', 'setCurrentStep']);
+
+        templateApi.createTemplate.and.returnValue(of({ templateId: 'template-1' }));
+        router.navigate.and.returnValue(Promise.resolve(true));
+
+        component = new VisualTemplateBuilderComponent(
+            router,
+            templateApi,
+            wizardState,
+            new I18nService()
+        );
+    });
+
+    it('creates stable field names from final visible labels', () => {
+        component.templateName = 'Geography';
+        component.frontFields = [
+            {
+                tempId: 'front-1',
+                name: 'text',
+                type: 'text',
+                label: ' Capital ',
+                helpText: '',
+                required: true
+            } as any,
+            {
+                tempId: 'front-2',
+                name: 'image',
+                type: 'text',
+                label: 'Capital',
+                helpText: '',
+                required: false
+            } as any
+        ];
+        component.backFields = [
+            {
+                tempId: 'back-1',
+                name: 'rich_text',
+                type: 'rich_text',
+                label: 'Answer',
+                helpText: '',
+                required: true
+            } as any
+        ];
+
+        component.saveTemplate();
+
+        const request = templateApi.createTemplate.calls.mostRecent().args[0];
+        expect(request.layout.front).toEqual(['capital', 'capital_2']);
+        expect(request.layout.back).toEqual(['answer']);
+        expect(request.fields.map((field: { name: string; label: string }) => [field.name, field.label])).toEqual([
+            ['capital', 'Capital'],
+            ['capital_2', 'Capital'],
+            ['answer', 'Answer']
+        ]);
+    });
+
+    it('uses the palette label when a dropped field label is still blank', () => {
+        component.templateName = 'Language';
+        component.frontFields = [
+            {
+                tempId: 'front-1',
+                name: '',
+                type: 'text',
+                label: '',
+                helpText: '',
+                required: true
+            } as any
+        ];
+        component.backFields = [
+            {
+                tempId: 'back-1',
+                name: '',
+                type: 'markdown',
+                label: 'Details',
+                helpText: '',
+                required: true
+            } as any
+        ];
+
+        component.saveTemplate();
+
+        const request = templateApi.createTemplate.calls.mostRecent().args[0];
+        expect(request.fields[0]).toEqual(jasmine.objectContaining({
+            name: 'text',
+            label: 'Text'
+        }));
+    });
+});

--- a/frontend/src/app/features/wizard/visual-template-builder.component.ts
+++ b/frontend/src/app/features/wizard/visual-template-builder.component.ts
@@ -134,6 +134,7 @@ interface BuilderState {
               [style.height]="getCardHeight()"
               cdkDropList
               id="cardDropZone"
+              [cdkDropListAutoScrollDisabled]="true"
               [cdkDropListData]="currentFields"
               [cdkDropListConnectedTo]="[]"
               (cdkDropListEntered)="onCardDropEntered($event)"
@@ -582,7 +583,8 @@ interface BuilderState {
         gap: var(--spacing-sm);
         transition: height 0.2s ease;
         position: relative;
-        overflow: hidden;
+        overflow: clip;
+        overscroll-behavior: none;
       }
 
       .card-empty {
@@ -607,6 +609,12 @@ interface BuilderState {
         cursor: pointer;
         transition: all 0.15s;
         min-height: 50px;
+        overflow: hidden;
+        scrollbar-width: none;
+      }
+
+      .field-row::-webkit-scrollbar {
+        display: none;
       }
 
       .field-row:hover {
@@ -746,6 +754,12 @@ interface BuilderState {
         box-sizing: border-box;
         border-radius: var(--border-radius-md);
         box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+        overflow: hidden;
+        scrollbar-width: none;
+      }
+
+      .cdk-drag-preview::-webkit-scrollbar {
+        display: none;
       }
 
       .cdk-drag-placeholder {
@@ -937,17 +951,11 @@ export class VisualTemplateBuilderComponent implements OnInit, OnDestroy {
             const paletteField = event.item.data as PaletteField;
 
             if (this.isPaletteDragData(paletteField) && !paletteField.inDev) {
-                const existingNames = [
-                    ...this.frontFields.map(f => f.name),
-                    ...this.backFields.map(f => f.name)
-                ];
-                const fieldName = this.generateFieldName(paletteField.label, existingNames);
-
                 const newField: BuilderField = {
                     tempId: `field-${Date.now()}-${this.tempIdCounter++}`,
-                    name: fieldName,
+                    name: '',
                     type: paletteField.type,
-                    label: '',
+                    label: paletteField.label,
                     helpText: '',
                     required: false
                 };
@@ -1062,10 +1070,13 @@ export class VisualTemplateBuilderComponent implements OnInit, OnDestroy {
 
         this.saving = true;
 
+        const namedFrontFields = this.buildNamedFields(this.frontFields);
+        const namedBackFields = this.buildNamedFields(this.backFields, namedFrontFields.map(field => field.name));
+
         const fields: CreateFieldTemplateRequest[] = [
-            ...this.frontFields.map((field, index) => ({
+            ...namedFrontFields.map((field, index) => ({
                 name: field.name,
-                label: field.label.trim() || this.getFieldDisplayLabel(field),
+                label: field.label,
                 fieldType: field.type,
                 isRequired: field.required,
                 isOnFront: true,
@@ -1073,9 +1084,9 @@ export class VisualTemplateBuilderComponent implements OnInit, OnDestroy {
                 helpText: field.helpText || null,
                 defaultValue: null
             })),
-            ...this.backFields.map((field, index) => ({
+            ...namedBackFields.map((field, index) => ({
                 name: field.name,
-                label: field.label.trim() || this.getFieldDisplayLabel(field),
+                label: field.label,
                 fieldType: field.type,
                 isRequired: field.required,
                 isOnFront: false,
@@ -1090,8 +1101,8 @@ export class VisualTemplateBuilderComponent implements OnInit, OnDestroy {
             description: this.templateDescription.trim(),
             isPublic: this.makePublic,
             layout: {
-                front: this.frontFields.map(f => f.name),
-                back: this.backFields.map(f => f.name)
+                front: namedFrontFields.map(f => f.name),
+                back: namedBackFields.map(f => f.name)
             },
             fields
         };
@@ -1144,6 +1155,30 @@ export class VisualTemplateBuilderComponent implements OnInit, OnDestroy {
 
     private clearDraft(): void {
         localStorage.removeItem(this.STORAGE_KEY);
+    }
+
+    private buildNamedFields(fields: BuilderField[], initialNames: string[] = []): Array<BuilderField & { name: string; label: string }> {
+        const existingNames = [...initialNames];
+
+        return fields.map(field => {
+            const label = this.resolveFieldLabel(field);
+            const name = this.generateFieldName(label, existingNames);
+            existingNames.push(name);
+
+            return {
+                ...field,
+                name,
+                label
+            };
+        });
+    }
+
+    private resolveFieldLabel(field: BuilderField): string {
+        return field.label.trim() || this.getPaletteLabel(field.type);
+    }
+
+    private getPaletteLabel(type: FieldType): string {
+        return this.paletteFields.find(field => field.type === type)?.label || type;
     }
 
     private isPaletteDragData(data: unknown): data is PaletteField {


### PR DESCRIPTION
## Описание
  - В visual builder отключил внутренний CDK auto-scroll у drop-zone и скрыл scrollbar у drag preview.
  - Поля больше не получают backend name из типа поля в момент drop: при сохранении name строится из финального
    видимого label, с инкрементом дубликатов как в обычном создателе.

  - Добавил unit-тесты на генерацию fields/layout визуального билдера.
  - Переделал deck-meta в профиле колоды в адаптивную визуальную сетку с иконками, акцентами и Liquid Glass-слоем.
  - Админский popup редактирования карточки в public browser привёл к стилю модалки из своей колоды: скругление, solid/
    glass surface, фиксированные header/actions, scroll только в body.


## Тип изменений
Отметьте нужное:
- [ ] 🆕 Новая функциональность
- [X] 🐞 Исправление ошибки
- [X] 🧹 Рефакторинг / улучшения кода
- [ ] 📖 Документация
- [ ] ⚙️ Настройка CI/CD / инфраструктуры