### PR TITLE
Audit/ai card generation checkup

### DIFF
--- a/backend/services/ai/src/main/java/app/mnema/ai/provider/openai/OpenAiClient.java
+++ b/backend/services/ai/src/main/java/app/mnema/ai/provider/openai/OpenAiClient.java
@@ -335,17 +335,20 @@ public class OpenAiClient {
         if (request.format() != null && !request.format().isBlank()) {
             payload.put("output_format", request.format());
         }
-        // Ollama OpenAI compatibility expects b64_json for image payloads.
-        payload.put("response_format", "b64_json");
-        RestClient.RequestBodySpec spec = restClient.post()
-                .uri("/v1/images/generations")
-                .contentType(MediaType.APPLICATION_JSON);
-        if (hasApiKey(apiKey)) {
-            spec = spec.header(HttpHeaders.AUTHORIZATION, bearer(apiKey));
+        if (shouldSendImageResponseFormat(request.model())) {
+            payload.put("response_format", "b64_json");
         }
-        JsonNode response = spec.body(payload)
-                .retrieve()
-                .body(JsonNode.class);
+        JsonNode response = ProviderRetrySupport.executeTextRequest("OpenAI image", LOGGER, () -> {
+            RestClient.RequestBodySpec spec = restClient.post()
+                    .uri("/v1/images/generations")
+                    .contentType(MediaType.APPLICATION_JSON);
+            if (hasApiKey(apiKey)) {
+                spec = spec.header(HttpHeaders.AUTHORIZATION, bearer(apiKey));
+            }
+            return spec.body(payload)
+                    .retrieve()
+                    .body(JsonNode.class);
+        });
 
         if (response == null) {
             throw new IllegalStateException("OpenAI image response is empty");
@@ -371,6 +374,14 @@ public class OpenAiClient {
         String outputFormat = response.path("output_format").asText(null);
         String mimeType = resolveImageMimeType(outputFormat, request.format());
         return new OpenAiImageResult(bytes, mimeType, revisedPrompt, model);
+    }
+
+    private boolean shouldSendImageResponseFormat(String model) {
+        if (localGatewayBaseUrl) {
+            return true;
+        }
+        String normalized = model == null ? "" : model.trim().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("dall-e-");
     }
 
     public OpenAiVideoJob createVideoJob(String apiKey, OpenAiVideoRequest request) {

--- a/backend/services/ai/src/main/java/app/mnema/ai/provider/openai/OpenAiJobProcessor.java
+++ b/backend/services/ai/src/main/java/app/mnema/ai/provider/openai/OpenAiJobProcessor.java
@@ -99,6 +99,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
     private static final int DEFAULT_TTS_MAX_RETRIES = 5;
     private static final long DEFAULT_TTS_RETRY_INITIAL_DELAY_MS = 2000L;
     private static final long DEFAULT_TTS_RETRY_MAX_DELAY_MS = 30000L;
+    private static final int OPENAI_TTS_MAX_INPUT_CHARS = 4096;
     private static final int DEFAULT_VISION_MAX_OUTPUT_TOKENS = 800;
     private static final int DEFAULT_SOURCE_NORMALIZATION_MAX_OUTPUT_TOKENS = 1500;
     private static final String STEP_LOAD_SOURCE = "load_source";
@@ -238,9 +239,9 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         }
         if (MODE_IMPORT_GENERATE.equalsIgnoreCase(mode)) {
             if (isDraftQualityGateEnabled(params)) {
-                return List.of(STEP_LOAD_SOURCE, STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_ANALYZE_CONTENT, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO, STEP_APPLY_CHANGES);
+                return List.of(STEP_LOAD_SOURCE, STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_ANALYZE_CONTENT, STEP_APPLY_CHANGES, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO);
             }
-            return List.of(STEP_LOAD_SOURCE, STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO, STEP_APPLY_CHANGES);
+            return List.of(STEP_LOAD_SOURCE, STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_APPLY_CHANGES, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO);
         }
         if (MODE_AUDIT.equalsIgnoreCase(mode) || MODE_CARD_AUDIT.equalsIgnoreCase(mode)) {
             return List.of(STEP_PREPARE_CONTEXT, STEP_ANALYZE_CONTENT);
@@ -253,9 +254,9 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         }
         if (MODE_GENERATE_CARDS.equalsIgnoreCase(mode)) {
             if (isDraftQualityGateEnabled(params)) {
-                return List.of(STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_ANALYZE_CONTENT, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO, STEP_APPLY_CHANGES);
+                return List.of(STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_ANALYZE_CONTENT, STEP_APPLY_CHANGES, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO);
             }
-            return List.of(STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO, STEP_APPLY_CHANGES);
+            return List.of(STEP_PREPARE_CONTEXT, STEP_GENERATE_CONTENT, STEP_APPLY_CHANGES, STEP_GENERATE_MEDIA, STEP_GENERATE_AUDIO);
         }
         return List.of(STEP_GENERATE_CONTENT);
     }
@@ -2462,22 +2463,6 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                                                        String accessToken) {
         ImageConfig imageConfig = resolveImageConfig(params, true);
         VideoConfig videoConfig = resolveVideoConfig(params, true);
-        DraftMediaPreparationResult draftMediaResult = runStep(job, params, STEP_GENERATE_MEDIA, () -> prepareDraftMedia(
-                job,
-                apiKey,
-                context.template(),
-                generated.drafts(),
-                context.fieldTypes(),
-                imageConfig,
-                videoConfig
-        ));
-        DraftTtsPreparationResult draftTtsResult = runStep(job, params, STEP_GENERATE_AUDIO, () -> applyTtsToDrafts(
-                job,
-                apiKey,
-                params,
-                generated.drafts(),
-                context.template()
-        ));
         List<CreateCardRequestPayload> requests = generated.drafts().stream()
                 .map(draft -> new CreateCardRequestPayload(draft.content(), null, null, null, null, null))
                 .toList();
@@ -2487,8 +2472,19 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                 accessToken,
                 job.getJobId()
         ));
-        MediaApplyResult mediaResult = materializeDraftMediaResult(createdCards, draftMediaResult);
-        TtsApplyResult ttsResult = materializeDraftTtsResult(createdCards, draftTtsResult);
+        AtomicApplyResult generatedMediaResult = applyGeneratedCardMediaAndTts(
+                job,
+                apiKey,
+                params,
+                context,
+                generated.drafts(),
+                createdCards,
+                accessToken,
+                imageConfig,
+                videoConfig
+        );
+        MediaApplyResult mediaResult = generatedMediaResult.mediaResult();
+        TtsApplyResult ttsResult = generatedMediaResult.ttsResult();
 
         ObjectNode summary = objectMapper.createObjectNode();
         summary.put("mode", MODE_GENERATE_CARDS);
@@ -2496,6 +2492,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         summary.put("templateId", context.publicDeck().templateId().toString());
         summary.put("requestedCards", requestedCount);
         summary.put("createdCards", requests.size());
+        summary.put("mediaAppliedAfterCreate", true);
         summary.put("duplicatesSkippedExact", generated.droppedExact());
         summary.put("duplicatesSkippedPrimary", generated.droppedPrimary());
         summary.put("duplicatesSkippedSemantic", generated.droppedSemantic());
@@ -2559,6 +2556,203 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
             return left;
         }
         return left + right;
+    }
+
+    private AtomicApplyResult applyGeneratedCardMediaAndTts(AiJobEntity job,
+                                                            String apiKey,
+                                                            JsonNode params,
+                                                            GenerationContext context,
+                                                            List<CardDraft> drafts,
+                                                            List<CoreUserCardResponse> createdCards,
+                                                            String accessToken,
+                                                            ImageConfig imageConfig,
+                                                            VideoConfig videoConfig) {
+        if (createdCards == null || createdCards.isEmpty() || drafts == null || drafts.isEmpty()) {
+            return new AtomicApplyResult(new MediaApplyResult(0, 0, 0), new TtsApplyResult(0, 0, 0, null, null));
+        }
+        List<GeneratedCardMutation> mutations = new ArrayList<>();
+        int limit = Math.min(createdCards.size(), drafts.size());
+        for (int i = 0; i < limit; i++) {
+            CoreUserCardResponse card = createdCards.get(i);
+            CardDraft draft = drafts.get(i);
+            if (card != null && card.userCardId() != null && draft != null && draft.content() != null) {
+                mutations.add(new GeneratedCardMutation(i, card, draft));
+            }
+        }
+        if (mutations.isEmpty()) {
+            return new AtomicApplyResult(new MediaApplyResult(0, 0, 0), new TtsApplyResult(0, 0, 0, null, null));
+        }
+
+        MediaApplyResult mediaResult = runStep(job, params, STEP_GENERATE_MEDIA, () -> applyGeneratedCardMedia(
+                job,
+                apiKey,
+                context,
+                mutations,
+                accessToken,
+                imageConfig,
+                videoConfig
+        ));
+        TtsApplyResult ttsResult = runStep(job, params, STEP_GENERATE_AUDIO, () -> applyGeneratedCardTts(
+                job,
+                apiKey,
+                params,
+                context,
+                mutations,
+                accessToken
+        ));
+        return new AtomicApplyResult(mediaResult, ttsResult);
+    }
+
+    private MediaApplyResult applyGeneratedCardMedia(AiJobEntity job,
+                                                     String apiKey,
+                                                     GenerationContext context,
+                                                     List<GeneratedCardMutation> mutations,
+                                                     String accessToken,
+                                                     ImageConfig imageConfig,
+                                                     VideoConfig videoConfig) {
+        int updatedCards = 0;
+        int imagesGenerated = 0;
+        int videosGenerated = 0;
+        Set<UUID> updatedCardIds = new LinkedHashSet<>();
+        Map<UUID, List<String>> cardErrors = new LinkedHashMap<>();
+        for (GeneratedCardMutation mutation : mutations) {
+            CoreUserCardResponse card = mutation.card();
+            CardDraft draft = mutation.draft();
+            if (draft.mediaPrompts() == null || draft.mediaPrompts().isEmpty()) {
+                executionService.updateStepProgress(job.getJobId(), STEP_GENERATE_MEDIA, (mutation.index() + 1) / (double) Math.max(1, mutations.size()));
+                continue;
+            }
+            ObjectNode updatedContent = loadLatestContent(
+                    job.getJobId(),
+                    job.getDeckId(),
+                    card.userCardId(),
+                    accessToken,
+                    baseGeneratedContent(card, draft)
+            );
+            ContentMutationResult contentResult = applyDraftMediaToContent(
+                    job,
+                    apiKey,
+                    updatedContent,
+                    draft.mediaPrompts(),
+                    context.fieldTypes(),
+                    imageConfig,
+                    videoConfig,
+                    card.userCardId().toString()
+            );
+            appendErrors(cardErrors, card.userCardId(), contentResult.errors());
+            imagesGenerated += contentResult.imagesGenerated();
+            videosGenerated += contentResult.videosGenerated();
+            if (contentResult.changed()) {
+                ankiSupport.applyIfPresent(updatedContent, context.template());
+                UpdateUserCardRequest update = new UpdateUserCardRequest(
+                        card.userCardId(),
+                        null,
+                        false,
+                        false,
+                        null,
+                        updatedContent
+                );
+                String cardScope = resolveCardUpdateScope(context.updateScope(), card);
+                UUID operationId = resolveUpdateOperationId(cardScope, job);
+                try {
+                    coreApiClient.updateUserCard(job.getDeckId(), card.userCardId(), update, accessToken, cardScope, operationId);
+                    updatedCards++;
+                    updatedCardIds.add(card.userCardId());
+                } catch (Exception ex) {
+                    appendCardError(cardErrors, card.userCardId(), "media", "failed to apply generated media: " + summarizeError(ex));
+                    LOGGER.warn("OpenAI generated media apply failed jobId={} cardId={} error={}",
+                            job.getJobId(),
+                            card.userCardId(),
+                            summarizeError(ex));
+                }
+            }
+            executionService.updateStepProgress(job.getJobId(), STEP_GENERATE_MEDIA, (mutation.index() + 1) / (double) Math.max(1, mutations.size()));
+        }
+        return new MediaApplyResult(updatedCards, imagesGenerated, videosGenerated, updatedCardIds, cardErrors);
+    }
+
+    private TtsApplyResult applyGeneratedCardTts(AiJobEntity job,
+                                                 String apiKey,
+                                                 JsonNode params,
+                                                 GenerationContext context,
+                                                 List<GeneratedCardMutation> mutations,
+                                                 String accessToken) {
+        int generated = 0;
+        int charsGenerated = 0;
+        int updatedCards = 0;
+        String model = null;
+        String error = null;
+        Set<UUID> updatedCardIds = new LinkedHashSet<>();
+        Map<UUID, List<String>> cardErrors = new LinkedHashMap<>();
+        for (GeneratedCardMutation mutation : mutations) {
+            CoreUserCardResponse card = mutation.card();
+            ObjectNode updatedContent = loadLatestContent(
+                    job.getJobId(),
+                    job.getDeckId(),
+                    card.userCardId(),
+                    accessToken,
+                    baseGeneratedContent(card, mutation.draft())
+            );
+            TtsContentApplyResult result = applyTtsToContent(
+                    job,
+                    apiKey,
+                    params.path("tts"),
+                    updatedContent,
+                    context.template(),
+                    null,
+                    card.userCardId(),
+                    card.userCardId().toString()
+            );
+            appendErrors(cardErrors, card.userCardId(), result.errors());
+            generated += result.generated();
+            charsGenerated += result.charsGenerated();
+            if (model == null) {
+                model = result.model();
+            }
+            if (error == null && !result.errors().isEmpty()) {
+                error = result.errors().getFirst();
+            }
+            if (result.updated()) {
+                ankiSupport.applyIfPresent(updatedContent, context.template());
+                UpdateUserCardRequest update = new UpdateUserCardRequest(
+                        card.userCardId(),
+                        null,
+                        false,
+                        false,
+                        null,
+                        updatedContent
+                );
+                String cardScope = resolveCardUpdateScope(context.updateScope(), card);
+                UUID operationId = resolveUpdateOperationId(cardScope, job);
+                try {
+                    coreApiClient.updateUserCard(job.getDeckId(), card.userCardId(), update, accessToken, cardScope, operationId);
+                    updatedCards++;
+                    updatedCardIds.add(card.userCardId());
+                } catch (Exception ex) {
+                    appendCardError(cardErrors, card.userCardId(), "tts", "failed to apply generated audio: " + summarizeError(ex));
+                    if (error == null) {
+                        error = summarizeError(ex);
+                    }
+                    LOGGER.warn("OpenAI generated audio apply failed jobId={} cardId={} error={}",
+                            job.getJobId(),
+                            card.userCardId(),
+                            summarizeError(ex));
+                }
+            }
+            executionService.updateStepProgress(job.getJobId(), STEP_GENERATE_AUDIO, (mutation.index() + 1) / (double) Math.max(1, mutations.size()));
+        }
+        return new TtsApplyResult(generated, updatedCards, charsGenerated, model, error, updatedCardIds, cardErrors);
+    }
+
+    private ObjectNode baseGeneratedContent(CoreUserCardResponse card, CardDraft draft) {
+        JsonNode content = card == null ? null : card.effectiveContent();
+        if (content != null && content.isObject()) {
+            return content.deepCopy();
+        }
+        if (draft != null && draft.content() != null) {
+            return draft.content().deepCopy();
+        }
+        return objectMapper.createObjectNode();
     }
 
     private ObjectNode buildSourceCoverageNode(SourceCoverage coverage) {
@@ -2818,6 +3012,10 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         if (text == null || text.isBlank()) {
             throw new IllegalStateException("TTS text is required");
         }
+        int maxChars = resolveStandaloneTtsMaxChars(params);
+        if (text.length() > maxChars) {
+            throw new IllegalStateException("TTS text exceeds max input length " + maxChars);
+        }
         String model = textOrDefault(params.path("model"), props.defaultTtsModel());
         if (model == null || model.isBlank()) {
             throw new IllegalStateException("TTS model is required");
@@ -2856,9 +3054,16 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         summary.put("contentType", contentType);
         summary.put("fileName", fileName);
         summary.put("model", model);
+        summary.put("ttsGenerated", 1);
+        summary.put("ttsCharsGenerated", text.length());
         if (voice != null && !voice.isBlank()) {
             summary.put("voice", voice);
         }
+        ObjectNode usageDetails = objectMapper.createObjectNode();
+        ObjectNode ttsDetails = usageDetails.putObject("tts");
+        ttsDetails.put("generated", 1);
+        ttsDetails.put("charsGenerated", text.length());
+        ttsDetails.put("model", model);
 
         return new AiJobProcessingResult(
                 summary,
@@ -2867,7 +3072,9 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                 null,
                 null,
                 BigDecimal.ZERO,
-                job.getInputHash()
+                job.getInputHash(),
+                AiJobStatus.completed,
+                usageDetails
         );
     }
 
@@ -4422,6 +4629,11 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                              String sourceText) {
     }
 
+    private record GeneratedCardMutation(int index,
+                                         CoreUserCardResponse card,
+                                         CardDraft draft) {
+    }
+
     private record ContentMutationResult(boolean changed,
                                          int imagesGenerated,
                                          int videosGenerated,
@@ -4459,20 +4671,6 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                                          int charsGenerated,
                                          String model,
                                          List<String> errors) {
-    }
-
-    private record DraftMediaPreparationResult(int imagesGenerated,
-                                               int videosGenerated,
-                                               Set<Integer> updatedDraftIndexes,
-                                               Map<Integer, List<String>> draftErrors) {
-    }
-
-    private record DraftTtsPreparationResult(int generated,
-                                             int charsGenerated,
-                                             String model,
-                                             String error,
-                                             Set<Integer> updatedDraftIndexes,
-                                             Map<Integer, List<String>> draftErrors) {
     }
 
     private record AtomicApplyResult(MediaApplyResult mediaResult,
@@ -5194,10 +5392,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         if (format == null || format.isBlank()) {
             format = "mp3";
         }
-        int maxChars = ttsNode.path("maxChars").isInt() ? ttsNode.path("maxChars").asInt() : 300;
-        if (maxChars < 1) {
-            maxChars = 1;
-        }
+        int maxChars = resolveTtsMaxChars(ttsNode);
 
         int generated = 0;
         int charsGenerated = 0;
@@ -5217,6 +5412,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                     continue;
                 }
                 if (text.length() > maxChars) {
+                    appendCardError(cardErrors, card.userCardId(), mapping.targetField(), "text exceeds TTS max input length " + maxChars);
                     continue;
                 }
                 byte[] audio;
@@ -5324,10 +5520,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         if (format == null || format.isBlank()) {
             format = "mp3";
         }
-        int maxChars = ttsNode.path("maxChars").isInt() ? ttsNode.path("maxChars").asInt() : 300;
-        if (maxChars < 1) {
-            maxChars = 1;
-        }
+        int maxChars = resolveTtsMaxChars(ttsNode);
 
         int generated = 0;
         int charsGenerated = 0;
@@ -5350,6 +5543,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                     continue;
                 }
                 if (text.length() > maxChars) {
+                    appendCardError(cardErrors, card.userCardId(), mapping.targetField(), "text exceeds TTS max input length " + maxChars);
                     continue;
                 }
                 byte[] audio;
@@ -5412,63 +5606,6 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         return new TtsApplyResult(generated, updatedCards, charsGenerated, model, ttsError, updatedCardIds, cardErrors);
     }
 
-    private DraftTtsPreparationResult applyTtsToDrafts(AiJobEntity job,
-                                                       String apiKey,
-                                                       JsonNode params,
-                                                       List<CardDraft> drafts,
-                                                       CoreTemplateResponse template) {
-        JsonNode ttsNode = params.path("tts");
-        if (!ttsNode.path("enabled").asBoolean(false)) {
-            return new DraftTtsPreparationResult(0, 0, null, null, Set.of(), Map.of());
-        }
-        if (drafts == null || drafts.isEmpty()) {
-            return new DraftTtsPreparationResult(0, 0, null, null, Set.of(), Map.of());
-        }
-        int generated = 0;
-        int charsGenerated = 0;
-        String model = null;
-        String error = null;
-        Set<Integer> updatedDraftIndexes = new LinkedHashSet<>();
-        Map<Integer, List<String>> draftErrors = new LinkedHashMap<>();
-        for (int i = 0; i < drafts.size(); i++) {
-            CardDraft draft = drafts.get(i);
-            if (draft == null || draft.content() == null) {
-                continue;
-            }
-            TtsContentApplyResult result = applyTtsToContent(
-                    job,
-                    apiKey,
-                    ttsNode,
-                    draft.content(),
-                    template,
-                    null,
-                    null,
-                    "draft-" + i
-            );
-            generated += result.generated();
-            charsGenerated += result.charsGenerated();
-            if (model == null) {
-                model = result.model();
-            }
-            if (error == null && !result.errors().isEmpty()) {
-                error = result.errors().getFirst();
-            }
-            if (result.updated()) {
-                ankiSupport.applyIfPresent(draft.content(), template);
-                updatedDraftIndexes.add(i);
-            }
-            if (!result.errors().isEmpty()) {
-                draftErrors.put(i, new ArrayList<>(result.errors()));
-            }
-            executionService.updateStepProgress(
-                    job.getJobId(),
-                    STEP_GENERATE_AUDIO,
-                    (i + 1) / (double) Math.max(1, drafts.size())
-            );
-        }
-        return new DraftTtsPreparationResult(generated, charsGenerated, model, error, updatedDraftIndexes, draftErrors);
-    }
-
     private TtsContentApplyResult applyTtsToContent(AiJobEntity job,
                                                     String apiKey,
                                                     JsonNode ttsNode,
@@ -5515,10 +5652,7 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         if (format == null || format.isBlank()) {
             format = "mp3";
         }
-        int maxChars = ttsNode.path("maxChars").isInt() ? ttsNode.path("maxChars").asInt() : 300;
-        if (maxChars < 1) {
-            maxChars = 1;
-        }
+        int maxChars = resolveTtsMaxChars(ttsNode);
 
         boolean updated = false;
         int generated = 0;
@@ -5529,7 +5663,11 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
                 continue;
             }
             String text = sanitizeTtsText(extractTextValue(updatedContent, mapping.sourceField()));
-            if (text == null || text.isBlank() || text.length() > maxChars) {
+            if (text == null || text.isBlank()) {
+                continue;
+            }
+            if (text.length() > maxChars) {
+                errors.add(formatFieldError(mapping.targetField(), "text exceeds TTS max input length " + maxChars));
                 continue;
             }
             byte[] audio;
@@ -5934,53 +6072,6 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
             updatedCardIds.add(card.userCardId());
         }
         return new MediaApplyResult(updated, imagesGenerated, videosGenerated, updatedCardIds, cardErrors);
-    }
-
-    private DraftMediaPreparationResult prepareDraftMedia(AiJobEntity job,
-                                                          String apiKey,
-                                                          CoreTemplateResponse template,
-                                                          List<CardDraft> drafts,
-                                                          Map<String, String> fieldTypes,
-                                                          ImageConfig imageConfig,
-                                                          VideoConfig videoConfig) {
-        if (drafts == null || drafts.isEmpty()) {
-            return new DraftMediaPreparationResult(0, 0, Set.of(), Map.of());
-        }
-        int imagesGenerated = 0;
-        int videosGenerated = 0;
-        Set<Integer> updatedDraftIndexes = new LinkedHashSet<>();
-        Map<Integer, List<String>> draftErrors = new LinkedHashMap<>();
-        for (int i = 0; i < drafts.size(); i++) {
-            CardDraft draft = drafts.get(i);
-            if (draft == null || draft.content() == null) {
-                continue;
-            }
-            ContentMutationResult result = applyDraftMediaToContent(
-                    job,
-                    apiKey,
-                    draft.content(),
-                    draft.mediaPrompts(),
-                    fieldTypes,
-                    imageConfig,
-                    videoConfig,
-                    "draft-" + i
-            );
-            if (result.changed()) {
-                ankiSupport.applyIfPresent(draft.content(), template);
-                updatedDraftIndexes.add(i);
-            }
-            imagesGenerated += result.imagesGenerated();
-            videosGenerated += result.videosGenerated();
-            if (!result.errors().isEmpty()) {
-                draftErrors.put(i, new ArrayList<>(result.errors()));
-            }
-            executionService.updateStepProgress(
-                    job.getJobId(),
-                    STEP_GENERATE_MEDIA,
-                    (i + 1) / (double) Math.max(1, drafts.size())
-            );
-        }
-        return new DraftMediaPreparationResult(imagesGenerated, videosGenerated, updatedDraftIndexes, draftErrors);
     }
 
     private ContentMutationResult applyDraftMediaToContent(AiJobEntity job,
@@ -6466,6 +6557,23 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
         return Math.max(retries, 0);
     }
 
+    private int resolveTtsMaxChars(JsonNode ttsNode) {
+        int requested = ttsNode != null && ttsNode.path("maxChars").isInt()
+                ? ttsNode.path("maxChars").asInt()
+                : OPENAI_TTS_MAX_INPUT_CHARS;
+        if (requested < 1) {
+            return 1;
+        }
+        return Math.min(requested, OPENAI_TTS_MAX_INPUT_CHARS);
+    }
+
+    private int resolveStandaloneTtsMaxChars(JsonNode params) {
+        if (params != null && params.path("maxChars").isInt()) {
+            return Math.max(1, Math.min(params.path("maxChars").asInt(), OPENAI_TTS_MAX_INPUT_CHARS));
+        }
+        return resolveTtsMaxChars(params == null ? null : params.path("tts"));
+    }
+
     private long resolveTtsRetryInitialDelayMs() {
         Long delay = props.ttsRetryInitialDelayMs();
         if (delay == null || delay < 0) {
@@ -6586,76 +6694,6 @@ public class OpenAiJobProcessor implements AiProviderProcessor {
 
     private AiJobStatus resolveFinalStatus(boolean hasPartialFailures) {
         return hasPartialFailures ? AiJobStatus.partial_success : AiJobStatus.completed;
-    }
-
-    private MediaApplyResult materializeDraftMediaResult(List<CoreUserCardResponse> createdCards,
-                                                         DraftMediaPreparationResult draftResult) {
-        if (draftResult == null) {
-            return new MediaApplyResult(0, 0, 0);
-        }
-        Set<UUID> updatedCardIds = mapDraftIndexesToCardIds(createdCards, draftResult.updatedDraftIndexes());
-        return new MediaApplyResult(
-                updatedCardIds.size(),
-                draftResult.imagesGenerated(),
-                draftResult.videosGenerated(),
-                updatedCardIds,
-                mapDraftErrorsToCardIds(createdCards, draftResult.draftErrors())
-        );
-    }
-
-    private TtsApplyResult materializeDraftTtsResult(List<CoreUserCardResponse> createdCards,
-                                                     DraftTtsPreparationResult draftResult) {
-        if (draftResult == null) {
-            return new TtsApplyResult(0, 0, null, null);
-        }
-        Set<UUID> updatedCardIds = mapDraftIndexesToCardIds(createdCards, draftResult.updatedDraftIndexes());
-        return new TtsApplyResult(
-                draftResult.generated(),
-                updatedCardIds.size(),
-                draftResult.charsGenerated(),
-                draftResult.model(),
-                draftResult.error(),
-                updatedCardIds,
-                mapDraftErrorsToCardIds(createdCards, draftResult.draftErrors())
-        );
-    }
-
-    private Set<UUID> mapDraftIndexesToCardIds(List<CoreUserCardResponse> createdCards,
-                                               Set<Integer> indexes) {
-        if (createdCards == null || createdCards.isEmpty() || indexes == null || indexes.isEmpty()) {
-            return Set.of();
-        }
-        Set<UUID> cardIds = new LinkedHashSet<>();
-        for (Integer index : indexes) {
-            if (index == null || index < 0 || index >= createdCards.size()) {
-                continue;
-            }
-            CoreUserCardResponse card = createdCards.get(index);
-            if (card != null && card.userCardId() != null) {
-                cardIds.add(card.userCardId());
-            }
-        }
-        return cardIds;
-    }
-
-    private Map<UUID, List<String>> mapDraftErrorsToCardIds(List<CoreUserCardResponse> createdCards,
-                                                            Map<Integer, List<String>> draftErrors) {
-        if (createdCards == null || createdCards.isEmpty() || draftErrors == null || draftErrors.isEmpty()) {
-            return Map.of();
-        }
-        Map<UUID, List<String>> cardErrors = new LinkedHashMap<>();
-        for (Map.Entry<Integer, List<String>> entry : draftErrors.entrySet()) {
-            Integer index = entry.getKey();
-            if (index == null || index < 0 || index >= createdCards.size()) {
-                continue;
-            }
-            CoreUserCardResponse card = createdCards.get(index);
-            if (card == null || card.userCardId() == null || entry.getValue() == null || entry.getValue().isEmpty()) {
-                continue;
-            }
-            cardErrors.computeIfAbsent(card.userCardId(), ignored -> new ArrayList<>()).addAll(entry.getValue());
-        }
-        return cardErrors;
     }
 
     private TtsApplyResult mergeTtsResults(TtsApplyResult left, TtsApplyResult right) {

--- a/backend/services/ai/src/main/java/app/mnema/ai/service/AiJobService.java
+++ b/backend/services/ai/src/main/java/app/mnema/ai/service/AiJobService.java
@@ -219,6 +219,7 @@ public class AiJobService {
         job.setStatus(AiJobStatus.canceled);
         job.setUpdatedAt(Instant.now());
         job.setCompletedAt(Instant.now());
+        job.setUserAccessToken(null);
         AiJobEntity saved = jobRepository.save(job);
         cancellationRegistry.cancel(jobId);
         return toResponse(saved);

--- a/backend/services/ai/src/main/java/app/mnema/ai/service/AiJobWorker.java
+++ b/backend/services/ai/src/main/java/app/mnema/ai/service/AiJobWorker.java
@@ -213,6 +213,7 @@ public class AiJobWorker {
         job.setLockedBy(null);
         job.setNextRunAt(null);
         job.setErrorMessage(null);
+        job.setUserAccessToken(null);
         if (result != null) {
             java.math.BigDecimal resolvedCost = costEstimator.estimateRecordedCost(job, result);
             usageLedgerService.recordUsage(
@@ -251,6 +252,9 @@ public class AiJobWorker {
         job.setStatus(nextStatus);
         job.setNextRunAt(nextRunAt);
         job.setCompletedAt(completedAt);
+        if (nextStatus == AiJobStatus.failed) {
+            job.setUserAccessToken(null);
+        }
 
         jdbcTemplate.update(
                 """
@@ -260,6 +264,7 @@ public class AiJobWorker {
                     next_run_at = ?,
                     completed_at = ?,
                     error_message = ?,
+                    user_access_token = case when cast(? as app_ai.ai_job_status) = 'failed'::app_ai.ai_job_status then null else user_access_token end,
                     locked_at = null,
                     locked_by = null,
                     updated_at = ?
@@ -271,6 +276,7 @@ public class AiJobWorker {
                 toSqlTimestamp(nextRunAt),
                 toSqlTimestamp(completedAt),
                 errorSummary,
+                nextStatus.name(),
                 toSqlTimestamp(now),
                 job.getJobId()
         );

--- a/backend/services/ai/src/test/java/app/mnema/ai/provider/openai/OpenAiClientTest.java
+++ b/backend/services/ai/src/test/java/app/mnema/ai/provider/openai/OpenAiClientTest.java
@@ -3,8 +3,10 @@ package app.mnema.ai.provider.openai;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResourceAccessException;
 
+import java.lang.reflect.Method;
 import java.net.SocketTimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +54,25 @@ class OpenAiClientTest {
     }
 
     @Test
+    void imageResponseFormatIsOmittedForGptImageModelsOnOpenAiApi() throws Exception {
+        OpenAiClient client = new OpenAiClient(RestClient.builder(), openAiProps("https://api.openai.com"), OBJECT_MAPPER);
+        Method method = OpenAiClient.class.getDeclaredMethod("shouldSendImageResponseFormat", String.class);
+        method.setAccessible(true);
+
+        assertThat((boolean) method.invoke(client, "gpt-image-1-mini")).isFalse();
+        assertThat((boolean) method.invoke(client, "dall-e-3")).isTrue();
+    }
+
+    @Test
+    void imageResponseFormatIsKeptForLocalGatewayCompatibility() throws Exception {
+        OpenAiClient client = new OpenAiClient(RestClient.builder(), openAiProps("http://localhost:8089"), OBJECT_MAPPER);
+        Method method = OpenAiClient.class.getDeclaredMethod("shouldSendImageResponseFormat", String.class);
+        method.setAccessible(true);
+
+        assertThat((boolean) method.invoke(client, "gpt-image-1-mini")).isTrue();
+    }
+
+    @Test
     void summarizeResponseIncludesStatusModelAndOutputTypes() {
         ObjectNode response = OBJECT_MAPPER.createObjectNode();
         response.put("status", "completed");
@@ -63,5 +84,32 @@ class OpenAiClientTest {
                 .contains("status=completed")
                 .contains("model=qwen3:4b")
                 .contains("outputTypes=reasoning");
+    }
+
+    private static OpenAiProps openAiProps(String baseUrl) {
+        return new OpenAiProps(
+                baseUrl,
+                "",
+                "gpt-4.1-mini",
+                "gpt-4o-mini-tts",
+                "alloy",
+                "mp3",
+                "gpt-4o-mini-transcribe",
+                "gpt-image-1-mini",
+                "1024x1024",
+                "low",
+                "natural",
+                "png",
+                "sora-2",
+                5,
+                "720p",
+                60,
+                12,
+                5,
+                2_000L,
+                30_000L,
+                10_000L,
+                600_000L
+        );
     }
 }

--- a/backend/services/ai/src/test/java/app/mnema/ai/provider/openai/OpenAiJobProcessorTest.java
+++ b/backend/services/ai/src/test/java/app/mnema/ai/provider/openai/OpenAiJobProcessorTest.java
@@ -2,6 +2,7 @@ package app.mnema.ai.provider.openai;
 
 import app.mnema.ai.client.core.CoreApiClient;
 import app.mnema.ai.client.media.MediaApiClient;
+import app.mnema.ai.client.media.MediaClientProps;
 import app.mnema.ai.domain.entity.AiJobEntity;
 import app.mnema.ai.domain.entity.AiProviderCredentialEntity;
 import app.mnema.ai.domain.type.AiJobStatus;
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResourceAccessException;
 
 import java.lang.reflect.Method;
@@ -29,11 +31,13 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,9 +104,9 @@ class OpenAiJobProcessorTest {
                 "prepare_context",
                 "generate_content",
                 "analyze_content",
+                "apply_changes",
                 "generate_media",
-                "generate_audio",
-                "apply_changes"
+                "generate_audio"
         );
     }
 
@@ -121,6 +125,128 @@ class OpenAiJobProcessorTest {
                 "generate_content",
                 "apply_changes"
         );
+    }
+
+    @Test
+    void handleGenerateCardsDoesNotGenerateMediaOrTtsBeforeCoreApplySucceeds() throws Exception {
+        OpenAiClient openAiClient = mock(OpenAiClient.class);
+        CoreApiClient coreApiClient = mock(CoreApiClient.class);
+        MediaApiClient mediaApiClient = mock(MediaApiClient.class);
+        OpenAiJobProcessor processor = createProcessor(
+                openAiClient,
+                coreApiClient,
+                mediaApiClient,
+                mock(AiJobExecutionService.class),
+                new CardNoveltyService(coreApiClient)
+        );
+        UUID deckId = UUID.randomUUID();
+        UUID publicDeckId = UUID.randomUUID();
+        UUID templateId = UUID.randomUUID();
+        ObjectNode params = OBJECT_MAPPER.createObjectNode();
+        params.put("__skipStepTracking", true);
+        params.put("mode", "generate_cards");
+        params.put("count", 1);
+        params.put("input", "one illustrated card");
+        params.putArray("fields").add("front").add("image").add("audio");
+        params.putObject("tts")
+                .put("enabled", true)
+                .put("model", "gpt-4o-mini-tts")
+                .put("maxChars", 4096);
+        AiJobEntity job = createJob(params, AiJobType.generic);
+        job.setDeckId(deckId);
+        job.setUserAccessToken("token");
+
+        when(coreApiClient.getUserDeck(deckId, "token"))
+                .thenReturn(new CoreApiClient.CoreUserDeckResponse(deckId, publicDeckId, 1, 1));
+        when(coreApiClient.getPublicDeck(publicDeckId, 1))
+                .thenReturn(new CoreApiClient.CorePublicDeckResponse(publicDeckId, 1, UUID.randomUUID(), "Deck", "Context", "en", templateId, 1));
+        when(coreApiClient.getTemplate(templateId, 1, "token"))
+                .thenReturn(new CoreApiClient.CoreTemplateResponse(
+                        templateId,
+                        1,
+                        1,
+                        "Basic",
+                        "",
+                        null,
+                        null,
+                        List.of(
+                                new CoreApiClient.CoreFieldTemplate(UUID.randomUUID(), "front", "Front", "text", true, true, 0),
+                                new CoreApiClient.CoreFieldTemplate(UUID.randomUUID(), "image", "Image", "image", false, false, 1),
+                                new CoreApiClient.CoreFieldTemplate(UUID.randomUUID(), "audio", "Audio", "audio", false, false, 2)
+                        )
+                ));
+        when(coreApiClient.getUserCards(deckId, 1, 3, "token")).thenReturn(new CoreApiClient.CoreUserCardPage(List.of()));
+        when(coreApiClient.getUserCards(deckId, 1, 200, "token")).thenReturn(new CoreApiClient.CoreUserCardPage(List.of()));
+        ObjectNode raw = OBJECT_MAPPER.createObjectNode();
+        raw.putObject("usage").put("input_tokens", 12).put("output_tokens", 6);
+        when(openAiClient.createResponse(any(), any())).thenReturn(new OpenAiResponseResult(
+                "{\"cards\":[{\"fields\":{\"front\":\"Q\",\"image\":\"clean diagram\",\"audio\":\"\"}}]}",
+                "gpt-4.1-mini",
+                12,
+                6,
+                raw
+        ));
+        when(coreApiClient.addCards(any(), any(), any(), any())).thenThrow(new IllegalStateException("core rejected batch"));
+
+        Method handleGenerateCards = OpenAiJobProcessor.class.getDeclaredMethod(
+                "handleGenerateCards",
+                AiJobEntity.class,
+                String.class,
+                JsonNode.class
+        );
+        handleGenerateCards.setAccessible(true);
+        try {
+            handleGenerateCards.invoke(processor, job, "sk-test", params);
+            fail("Expected core apply failure");
+        } catch (ReflectiveOperationException ex) {
+            assertThat(ex.getCause()).isInstanceOf(IllegalStateException.class);
+        }
+
+        verify(openAiClient, never()).createImage(any(), any());
+        verify(openAiClient, never()).createSpeech(any(), any());
+        verify(mediaApiClient, never()).directUpload(any(), any(), any(), any(), org.mockito.ArgumentMatchers.anyLong(), any());
+    }
+
+    @Test
+    void handleTtsRecordsGeneratedCountAndCharactersForCostAccounting() throws Exception {
+        OpenAiClient openAiClient = mock(OpenAiClient.class);
+        UUID mediaId = UUID.randomUUID();
+        MediaApiClient mediaApiClient = new MediaApiClient(RestClient.builder(), new MediaClientProps("http://localhost", "internal")) {
+            @Override
+            public UUID directUpload(UUID ownerUserId, String kind, String contentType, String fileName, long contentLength, java.io.InputStream inputStream) {
+                return mediaId;
+            }
+        };
+        OpenAiJobProcessor processor = createProcessor(
+                openAiClient,
+                mock(CoreApiClient.class),
+                mediaApiClient,
+                mock(AiJobExecutionService.class),
+                mock(CardNoveltyService.class)
+        );
+        byte[] mp3 = new byte[256];
+        mp3[0] = 'I';
+        mp3[1] = 'D';
+        mp3[2] = '3';
+        for (int i = 3; i < mp3.length; i++) {
+            mp3[i] = (byte) (i % 37);
+        }
+        when(openAiClient.createSpeech(any(), any())).thenReturn(mp3);
+        ObjectNode params = OBJECT_MAPPER.createObjectNode();
+        params.put("text", "Hello world");
+        params.put("model", "gpt-4o-mini-tts");
+        params.put("format", "mp3");
+        AiJobEntity job = createJob(params, AiJobType.tts);
+
+        Method handleTts = OpenAiJobProcessor.class.getDeclaredMethod("handleTts", AiJobEntity.class, String.class);
+        handleTts.setAccessible(true);
+        app.mnema.ai.service.AiJobProcessingResult result = (app.mnema.ai.service.AiJobProcessingResult) handleTts.invoke(processor, job, "sk-test");
+
+        assertThat(result.resultSummary().path("mediaId").asText()).isEqualTo(mediaId.toString());
+        assertThat(result.resultSummary().path("ttsGenerated").asInt()).isEqualTo(1);
+        assertThat(result.resultSummary().path("ttsCharsGenerated").asInt()).isEqualTo("Hello world".length());
+        assertThat(result.usageDetails().path("tts").path("generated").asInt()).isEqualTo(1);
+        assertThat(result.usageDetails().path("tts").path("charsGenerated").asInt()).isEqualTo("Hello world".length());
     }
 
     @Test
@@ -1235,6 +1361,20 @@ class OpenAiJobProcessorTest {
     }
 
     private static OpenAiJobProcessor createProcessor(OpenAiClient openAiClient) {
+        return createProcessor(
+                openAiClient,
+                mock(CoreApiClient.class),
+                mock(MediaApiClient.class),
+                mock(AiJobExecutionService.class),
+                mock(CardNoveltyService.class)
+        );
+    }
+
+    private static OpenAiJobProcessor createProcessor(OpenAiClient openAiClient,
+                                                      CoreApiClient coreApiClient,
+                                                      MediaApiClient mediaApiClient,
+                                                      AiJobExecutionService executionService,
+                                                      CardNoveltyService noveltyService) {
         return new OpenAiJobProcessor(
                 openAiClient,
                 new OpenAiProps(
@@ -1263,13 +1403,13 @@ class OpenAiJobProcessorTest {
                 ),
                 mock(SecretVault.class),
                 mock(AiProviderCredentialRepository.class),
-                mock(MediaApiClient.class),
+                mediaApiClient,
                 mock(AiImportContentService.class),
                 mock(AudioChunkingService.class),
-                mock(CoreApiClient.class),
-                mock(CardNoveltyService.class),
+                coreApiClient,
+                noveltyService,
                 OBJECT_MAPPER,
-                mock(AiJobExecutionService.class),
+                executionService,
                 200_000
         );
     }

--- a/backend/services/ai/src/test/java/app/mnema/ai/service/AiJobWorkerTest.java
+++ b/backend/services/ai/src/test/java/app/mnema/ai/service/AiJobWorkerTest.java
@@ -118,10 +118,11 @@ class AiJobWorkerTest {
         assertThat(job.getAttempts()).isEqualTo(2);
         assertThat(job.getCompletedAt()).isNotNull();
         assertThat(job.getNextRunAt()).isNull();
+        assertThat(job.getUserAccessToken()).isNull();
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jdbcTemplate).update(any(String.class), eq(1), eq("queued"), any(Timestamp.class), isNull(), eq("IllegalStateException"), any(Timestamp.class), eq(job.getJobId()));
-        verify(jdbcTemplate).update(any(String.class), eq(2), eq("failed"), isNull(), any(Timestamp.class), eq("IllegalArgumentException"), any(Timestamp.class), eq(job.getJobId()));
-        verify(jdbcTemplate, times(2)).update(sqlCaptor.capture(), any(), any(), any(), any(), any(), any(), any());
+        verify(jdbcTemplate).update(any(String.class), eq(1), eq("queued"), any(Timestamp.class), isNull(), eq("IllegalStateException"), eq("queued"), any(Timestamp.class), eq(job.getJobId()));
+        verify(jdbcTemplate).update(any(String.class), eq(2), eq("failed"), isNull(), any(Timestamp.class), eq("IllegalArgumentException"), eq("failed"), any(Timestamp.class), eq(job.getJobId()));
+        verify(jdbcTemplate, times(2)).update(sqlCaptor.capture(), any(), any(), any(), any(), any(), any(), any(), any());
         assertThat(sqlCaptor.getAllValues())
                 .allSatisfy(sql -> assertThat(sql).contains("status = cast(? as app_ai.ai_job_status)"));
     }

--- a/backend/services/core/src/main/java/app/mnema/core/deck/service/CardService.java
+++ b/backend/services/core/src/main/java/app/mnema/core/deck/service/CardService.java
@@ -930,6 +930,7 @@ public class CardService {
             if (!userDeck.getUserId().equals(currentUserId)) {
                 throw new SecurityException("Access denied to deck " + userDeckId);
             }
+            validateNoExactDuplicateCustomCards(currentUserId, userDeckId, requests);
             long offsetNanos = 0L;
             for (CreateCardRequest request : requests) {
                 validateTags(request.tags());
@@ -971,6 +972,7 @@ public class CardService {
 
         // 2) Не автор: добавляем только кастомные карты
         if (!canManageAsAuthor) {
+            validateNoExactDuplicateCustomCards(currentUserId, userDeckId, requests);
             long offsetNanos = 0L;
             for (CreateCardRequest request : requests) {
                 validateTags(request.tags());
@@ -1006,6 +1008,8 @@ public class CardService {
       - checksum обязателен для корректного sync и вычисляется на сервере по content.
       - order_index для добавляемых карт выставляется в конец, чтобы не плодить коллизии 1/2, 1/2 и т.п.
      */
+
+        validateNoExactDuplicatePublicCards(publicDeckId, latestDeck.getVersion(), requests);
 
         PublicDeckEntity targetDeck;
         int maxOrderIndex;
@@ -1196,6 +1200,73 @@ public class CardService {
     }
 
     private record NewDeckVersion(PublicDeckEntity deck, int maxOrderIndex) {
+    }
+
+    private void validateNoExactDuplicateCustomCards(UUID currentUserId,
+                                                     UUID userDeckId,
+                                                     List<CreateCardRequest> requests) {
+        Set<String> existingChecksums = new HashSet<>();
+        List<UserCardEntity> existingCards = userCardRepository.findByUserDeckId(userDeckId);
+        if (existingCards == null) {
+            existingCards = List.of();
+        }
+        for (UserCardEntity card : existingCards) {
+            if (card == null || card.isDeleted() || !currentUserId.equals(card.getUserId())) {
+                continue;
+            }
+            String checksum = computeChecksum(toUserCardDTO(card).effectiveContent());
+            if (checksum != null) {
+                existingChecksums.add(checksum);
+            }
+        }
+        validateNoExactDuplicateRequests(requests, false, existingChecksums);
+    }
+
+    private void validateNoExactDuplicatePublicCards(UUID publicDeckId,
+                                                     Integer deckVersion,
+                                                     List<CreateCardRequest> requests) {
+        Set<String> existingChecksums = new HashSet<>();
+        List<PublicCardEntity> existingCards = publicCardRepository.findByDeckIdAndDeckVersion(publicDeckId, deckVersion);
+        if (existingCards == null) {
+            existingCards = List.of();
+        }
+        for (PublicCardEntity card : existingCards) {
+            if (card == null || !card.isActive()) {
+                continue;
+            }
+            String checksum = normalizeChecksum(card.getChecksum());
+            if (checksum == null) {
+                checksum = computeChecksum(card.getContent());
+            }
+            if (checksum != null) {
+                existingChecksums.add(checksum);
+            }
+        }
+        validateNoExactDuplicateRequests(requests, true, existingChecksums);
+    }
+
+    private void validateNoExactDuplicateRequests(List<CreateCardRequest> requests,
+                                                  boolean publicContent,
+                                                  Set<String> existingChecksums) {
+        Set<String> batchChecksums = new HashSet<>();
+        for (CreateCardRequest request : requests) {
+            JsonNode content = publicContent
+                    ? request.content()
+                    : (request.contentOverride() != null ? request.contentOverride() : request.content());
+            if (content == null || content.isNull()) {
+                continue;
+            }
+            String checksum = computeChecksum(content);
+            if (checksum == null) {
+                continue;
+            }
+            if (!batchChecksums.add(checksum)) {
+                throw new IllegalArgumentException("Duplicate card content in request batch");
+            }
+            if (existingChecksums != null && existingChecksums.contains(checksum)) {
+                throw new IllegalArgumentException("Duplicate card content already exists in deck");
+            }
+        }
     }
 
     private void validateTags(String[] tags) {

--- a/backend/services/core/src/test/java/app/mnema/core/deck/service/CardServiceTest.java
+++ b/backend/services/core/src/test/java/app/mnema/core/deck/service/CardServiceTest.java
@@ -502,6 +502,42 @@ class CardServiceTest {
     }
 
     @Test
+    void addNewCardsToDeckBatch_rejectsExactDuplicateWithinLocalBatch() {
+        UUID userId = UUID.randomUUID();
+        UUID deckId = UUID.randomUUID();
+        when(userDeckRepository.findById(deckId)).thenReturn(Optional.of(userDeck(deckId, userId, null)));
+        when(userCardRepository.findByUserDeckId(deckId)).thenReturn(List.of());
+
+        assertThatThrownBy(() -> cardService.addNewCardsToDeckBatch(
+                userId,
+                deckId,
+                List.of(
+                        new CreateCardRequest(textContent("front", "Q"), 1, null, null, null, null),
+                        new CreateCardRequest(textContent("front", "Q"), 2, null, null, null, null)
+                ),
+                null
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate card content in request batch");
+    }
+
+    @Test
+    void addNewCardsToDeckBatch_rejectsExactDuplicateAlreadyInLocalDeck() {
+        UUID userId = UUID.randomUUID();
+        UUID deckId = UUID.randomUUID();
+        UserCardEntity existing = userCard(userId, deckId, null, true, false, null, null, textContent("front", "Q"));
+        when(userDeckRepository.findById(deckId)).thenReturn(Optional.of(userDeck(deckId, userId, null)));
+        when(userCardRepository.findByUserDeckId(deckId)).thenReturn(List.of(existing));
+
+        assertThatThrownBy(() -> cardService.addNewCardsToDeckBatch(
+                userId,
+                deckId,
+                List.of(new CreateCardRequest(textContent("front", "Q"), 1, null, null, null, null)),
+                null
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate card content already exists in deck");
+    }
+
+    @Test
     void addNewCardsToDeckBatch_forSubscriberCreatesCustomCardsOnly() {
         UUID userId = UUID.randomUUID();
         UUID deckId = UUID.randomUUID();
@@ -557,6 +593,28 @@ class CardServiceTest {
         });
         assertThat(deck.getCurrentVersion()).isEqualTo(2);
         verify(publicCardRepository, times(2)).saveAll(anyList());
+    }
+
+    @Test
+    void addNewCardsToDeckBatch_rejectsExactDuplicateAlreadyInPublicDeck() {
+        UUID userId = UUID.randomUUID();
+        UUID deckId = UUID.randomUUID();
+        UUID publicDeckId = UUID.randomUUID();
+        UserDeckEntity deck = userDeck(deckId, userId, publicDeckId);
+        PublicDeckEntity latestDeck = publicDeck(publicDeckId, 1, userId, UUID.randomUUID(), 1, true);
+        PublicCardEntity existingPublicCard = publicCard(publicDeckId, 1, UUID.randomUUID(), textContent("front", "Q"), null, true, null);
+
+        when(userDeckRepository.findById(deckId)).thenReturn(Optional.of(deck));
+        when(publicDeckRepository.findLatestByDeckId(publicDeckId)).thenReturn(Optional.of(latestDeck));
+        when(publicCardRepository.findByDeckIdAndDeckVersion(publicDeckId, 1)).thenReturn(List.of(existingPublicCard));
+
+        assertThatThrownBy(() -> cardService.addNewCardsToDeckBatch(
+                userId,
+                deckId,
+                List.of(new CreateCardRequest(textContent("front", "Q"), 1, null, null, null, null)),
+                null
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate card content already exists in deck");
     }
 
     @Test

--- a/frontend/src/app/features/decks/ai-add-cards-modal.component.ts
+++ b/frontend/src/app/features/decks/ai-add-cards-modal.component.ts
@@ -528,7 +528,7 @@ export class AiAddCardsModalComponent implements OnInit {
     ttsVoicePreset = signal('alloy');
     ttsVoiceCustom = signal('');
     ttsFormat = signal('mp3');
-    ttsMaxChars = signal(300);
+    ttsMaxChars = signal(4096);
     ttsMappings = signal<TtsMapping[]>([]);
     imageModel = signal('');
     imageModelCustom = signal('');
@@ -1170,7 +1170,7 @@ export class AiAddCardsModalComponent implements OnInit {
     }
 
     onTtsMaxCharsChange(value: number): void {
-        this.ttsMaxChars.set(value);
+        this.ttsMaxChars.set(this.clampTtsMaxChars(value));
         this.persistDraft();
     }
 
@@ -1378,7 +1378,7 @@ export class AiAddCardsModalComponent implements OnInit {
             if (typeof payload.ttsEnabled === 'boolean') this.ttsEnabled.set(payload.ttsEnabled);
             if (payload.ttsModel) this.ttsModel.set(payload.ttsModel);
             if (payload.ttsFormat) this.ttsFormat.set(payload.ttsFormat);
-            if (payload.ttsMaxChars) this.ttsMaxChars.set(payload.ttsMaxChars);
+            if (payload.ttsMaxChars) this.ttsMaxChars.set(this.clampTtsMaxChars(payload.ttsMaxChars));
             if (payload.ttsVoice) {
                 const options = this.voiceOptions();
                 if (options.includes(payload.ttsVoice)) {
@@ -1417,6 +1417,12 @@ export class AiAddCardsModalComponent implements OnInit {
             localStorage.removeItem(this.storageKey);
         } catch {
         }
+    }
+
+    private clampTtsMaxChars(value: number): number {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return 4096;
+        return Math.max(1, Math.min(4096, Math.trunc(numeric)));
     }
 
     private generateRequestId(): string {

--- a/frontend/src/app/features/decks/ai-enhance-deck-modal.component.ts
+++ b/frontend/src/app/features/decks/ai-enhance-deck-modal.component.ts
@@ -647,7 +647,7 @@ export class AiEnhanceDeckModalComponent implements OnInit {
     ttsVoicePreset = signal('alloy');
     ttsVoiceCustom = signal('');
     ttsFormat = signal('mp3');
-    ttsMaxChars = signal(300);
+    ttsMaxChars = signal(4096);
     ttsMappings = signal<TtsMapping[]>([]);
     imageModel = signal('');
     imageModelCustom = signal('');
@@ -1273,7 +1273,7 @@ export class AiEnhanceDeckModalComponent implements OnInit {
     }
 
     onTtsMaxCharsChange(value: number): void {
-        this.ttsMaxChars.set(value);
+        this.ttsMaxChars.set(this.clampTtsMaxChars(value));
         this.persistDraft();
     }
 
@@ -1843,7 +1843,7 @@ export class AiEnhanceDeckModalComponent implements OnInit {
             }
             if (payload.ttsModel) this.ttsModel.set(payload.ttsModel);
             if (payload.ttsFormat) this.ttsFormat.set(payload.ttsFormat);
-            if (payload.ttsMaxChars) this.ttsMaxChars.set(payload.ttsMaxChars);
+            if (payload.ttsMaxChars) this.ttsMaxChars.set(this.clampTtsMaxChars(payload.ttsMaxChars));
             if (payload.ttsVoice) {
                 const isPreset = this.openAiVoices.includes(payload.ttsVoice)
                     || this.geminiVoices.includes(payload.ttsVoice)
@@ -1889,6 +1889,12 @@ export class AiEnhanceDeckModalComponent implements OnInit {
         const tasks = actions.join(', ');
         const notes = this.notes().trim();
         return `${deckLabel} Improve the deck. Actions: ${tasks}.${notes ? ' Notes: ' + notes : ''}`.trim();
+    }
+
+    private clampTtsMaxChars(value: number): number {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return 4096;
+        return Math.max(1, Math.min(4096, Math.trunc(numeric)));
     }
 
     private generateRequestId(): string {

--- a/frontend/src/app/features/decks/ai-import-modal.component.ts
+++ b/frontend/src/app/features/decks/ai-import-modal.component.ts
@@ -950,7 +950,7 @@ export class AiImportModalComponent implements OnInit {
     ttsVoicePreset = signal('alloy');
     ttsVoiceCustom = signal('');
     ttsFormat = signal('mp3');
-    ttsMaxChars = signal(300);
+    ttsMaxChars = signal(4096);
     ttsMappings = signal<TtsMapping[]>([]);
 
     imageModel = signal('gpt-image-1');
@@ -1743,7 +1743,7 @@ export class AiImportModalComponent implements OnInit {
 
     onTtsMaxCharsChange(value: number): void {
         const numeric = Number(value);
-        this.ttsMaxChars.set(Number.isNaN(numeric) ? 300 : numeric);
+        this.ttsMaxChars.set(this.clampTtsMaxChars(numeric));
     }
 
     addTtsMapping(): void {
@@ -2249,7 +2249,7 @@ export class AiImportModalComponent implements OnInit {
                 this.ttsFormat.set(draft.ttsFormat);
             }
             if (Number.isFinite(draft.ttsMaxChars)) {
-                this.ttsMaxChars.set(Number(draft.ttsMaxChars));
+                this.ttsMaxChars.set(this.clampTtsMaxChars(Number(draft.ttsMaxChars)));
             }
             if (draft.ttsMappings?.length) {
                 this.ttsMappings.set(draft.ttsMappings.filter(mapping => !!mapping.sourceField && !!mapping.targetField));
@@ -2316,6 +2316,12 @@ export class AiImportModalComponent implements OnInit {
             this.clearDraft();
         }
         this.closed.emit();
+    }
+
+    private clampTtsMaxChars(value: number): number {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) return 4096;
+        return Math.max(1, Math.min(4096, Math.trunc(numeric)));
     }
 
     private generateRequestId(): string {


### PR DESCRIPTION
## Описание
 - Для add cards with ai карточки теперь сначала создаются в core, и только после успешного addCards генерируются media/TTS и
    патчатся уже существующие card ids.

  - Если media/TTS уже стоили денег, но patch в core упал, job становится partial_success с item-level error, а не уходит в полный
    повтор платных вызовов.

  - Standalone TTS теперь пишет ttsGenerated, ttsCharsGenerated и usage details, чтобы actual cost не была нулевой.
  - TTS лимит приведен к OpenAI Speech max input 4096, frontend defaults тоже 4096, значения clamp’ятся.
  - OpenAI image request стал model-aware: response_format=b64_json остается для local gateway / DALL-E, но не отправляется для GPT-
    image моделей; image calls получили retry wrapper.

  - User access token очищается при completed/canceled/final failed job.
  - Core теперь отсекает exact duplicate card content в batch add для локальных/custom и public-author сценариев.

## Тип изменений
- [ ] 🆕 Новая функциональность
- [X] 🐞 Исправление ошибки
- [X] 🧹 Рефакторинг / улучшения кода
- [ ] 📖 Документация
- [ ] ⚙️ Настройка CI/CD / инфраструктуры
